### PR TITLE
Pull middlewares logic from upstream

### DIFF
--- a/examples/middleware_worker.rb
+++ b/examples/middleware_worker.rb
@@ -1,0 +1,34 @@
+$: << File.expand_path('../lib', File.dirname(__FILE__))
+require 'sneakers'
+require 'sneakers/runner'
+
+class MiddlewareWorker
+  include Sneakers::Worker
+
+  from_queue 'middleware-demo',
+    ack: false
+
+  def work(message)
+    puts "******** MiddlewareWorker -> #{message}"
+  end
+end
+
+class DemoMiddleware
+  def initialize(app, *args)
+    @app = app
+    @args = args
+  end
+
+  def call(deserialized_msg, delivery_info, metadata, handler)
+    puts "******** DemoMiddleware - before; args #{@args}"
+    @app.call(deserialized_msg, delivery_info, metadata, handler)
+    puts "******** DemoMiddleware - after"
+  end
+end
+
+Sneakers.configure
+Sneakers.middleware.use(DemoMiddleware, foo: :bar)
+
+Sneakers.publish("{}", :to_queue => 'middleware-demo')
+r = Sneakers::Runner.new([MiddlewareWorker])
+r.run

--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -18,6 +18,7 @@ require 'sneakers/concerns/logging'
 require 'sneakers/concerns/metrics'
 require 'sneakers/handlers/oneshot'
 require 'sneakers/content_type'
+require 'sneakers/middleware/config'
 require 'sneakers/worker'
 require 'sneakers/publisher'
 
@@ -85,6 +86,10 @@ module Sneakers
   # Ripped off from https://github.com/mperham/sidekiq/blob/6ad6a3aa330deebd76c6cf0d353f66abd3bef93b/lib/sidekiq.rb#L165-L174
   def error_reporters
     CONFIG[:error_reporters]
+  end
+
+  def middleware
+    @middleware ||= Sneakers::Middleware::Config
   end
 
   private

--- a/lib/sneakers/middleware/config.rb
+++ b/lib/sneakers/middleware/config.rb
@@ -1,0 +1,23 @@
+module Sneakers
+  module Middleware
+    class Config
+      def self.use(klass, args)
+        middlewares << { class: klass, args: args }
+      end
+
+      def self.delete(klass)
+        middlewares.reject! { |el| el[:class] == klass }
+      end
+
+      def self.to_a
+        middlewares
+      end
+
+      def self.middlewares
+        @middlewares ||= []
+      end
+
+      private_class_method :middlewares
+    end
+  end
+end

--- a/lib/sneakers/version.rb
+++ b/lib/sneakers/version.rb
@@ -1,3 +1,3 @@
 module Sneakers
-  VERSION = "0.5.0.curb"
+  VERSION = "10.0.0.curb"
 end

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -37,5 +37,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'guard'
+  gem.add_development_dependency 'pry-byebug'
 end
 

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -411,6 +411,61 @@ describe Sneakers::Worker do
       w.do_work(header, nil, "msg", handler)
     end
 
+    describe 'middleware' do
+      let(:middleware) do
+        Class.new do
+          def initialize(app, *args)
+            @app = app
+          end
+
+          def call(deserialized_msg, delivery_info, metadata, handler)
+            @app.call(deserialized_msg, delivery_info, metadata, handler)
+          end
+        end
+      end
+
+      let(:worker) do
+        Class.new do
+          include Sneakers::Worker
+          from_queue 'defaults', ack: false
+
+          def work_with_params(msg, delivery_info, metadata)
+            msg
+          end
+        end
+      end
+
+      before do
+        Sneakers.middleware.use(middleware, 'args')
+
+        @delivery_info = Object.new
+        @metadata = Object.new
+        stub(@metadata).[](:content_type) { 'some/fake' }
+        @message = Object.new
+        @handler = Object.new
+      end
+
+      after do
+        Sneakers.middleware.delete(middleware)
+      end
+
+      it 'should process job and call #work_with_params/#work' do
+        w = worker.new(@queue, TestPool.new)
+        mock(w).work_with_params(@message, @delivery_info, @metadata).once
+
+        w.do_work(@delivery_info, @metadata, @message, @handler)
+      end
+
+      it "should call registered middleware" do
+        mock.proxy(middleware).new(instance_of(Proc), 'args').once do |res|
+          mock.proxy(res).call(@message, @delivery_info, @metadata, @handler).once
+        end
+
+        w = worker.new(@queue, TestPool.new)
+        w.do_work(@delivery_info, @metadata, @message, @handler)
+      end
+    end
+
     describe "with ack" do
       before do
         @delivery_info = Object.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'bundler/setup'
 require 'simplecov'
 require 'resolv'
+require 'pry-byebug'
+
 SimpleCov.start do
   add_filter "/spec/"
 end


### PR DESCRIPTION
# Scope

Datadog gem requires sneakers >= 2.12.0 version because it relies on `middlewares` logic that was introduced in that sneakers version. We pull this logic from upstream, but this PR does NOT sync all other commits between versions 2.6 and 2.12 because there were some breaking change introduced in upstream repo.

https://gocurb.atlassian.net/browse/CRS-5789

# Dependencies

https://github.com/ridecharge/ride_manager/pull/1325
https://github.com/ridecharge/vehicle/pull/551
https://github.com/ridecharge/clientservice/pull/1390

# Test Plan

* Make sure sneakers pods are able to be launched successfully.
* Make sure performance of sneakers workers did not get slower.
* Make sure both DD and NR are able to collect stats/errors about workers.
* Make sure there are no errors in logs/DD and NR.

# Deployment Plan

* Merge this PR to master, create a new tag and release.
* Update Gemfile's (and locks) of this gem in RM and Vehicle PRs.
* Deploy all apps as usually.
* Follow test plan.